### PR TITLE
Rework installation to allow single node server

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,79 +1,119 @@
-try {
-  $binariesPath = $(Join-Path (Split-Path -parent $MyInvocation.MyCommand.Definition) "..\binaries\")
-  $toolsPath = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
-  $wrapperExe = "$env:ChocolateyInstall\bin\nssm.exe"
+# Defaults
+$serviceName = "consul"
+$binariesPath = $(Join-Path (Split-Path -parent $MyInvocation.MyCommand.Definition) "..\binaries\")
+$toolsPath = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
+$wrapperExe = "$env:ChocolateyInstall\bin\nssm.exe"
+$serviceInstallationDirectory = "$env:PROGRAMDATA\consul"
+$serviceLogDirectory = "$serviceInstallationDirectory\logs"
+$serviceConfigDirectory = "$serviceInstallationDirectory\config"
+$serviceUiDirectory = "$serviceInstallationDirectory\ui"
+$serviceDataDirectory = "$serviceInstallationDirectory\data"
 
-  # Consul related variables
-  $consulVersion = '0.7.2'
-  $sourcePath = if (Get-ProcessorBits 32) {
-    $(Join-Path $binariesPath "$($consulVersion)_windows_386.zip")
-  } else {
-    $(Join-Path $binariesPath "$($consulVersion)_windows_amd64.zip")
-  }
-  $sourcePathUI = $(Join-Path $binariesPath "$($consulVersion)_web_ui.zip")
+$bindAddress = "127.0.0.1"
+$extraArgs = "-server -bootstrap-expect=1 -bind=$bindAddress"
 
-  # Unzip and move Consul
-  Get-ChocolateyUnzip  $sourcePath "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-  Get-ChocolateyUnzip  $sourcePathUI "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+# packageParameters -- https://github.com/chocolatey/choco/wiki/How-To-Parse-PackageParameters-Argument
+# https://github.com/chocolatey/choco/issues/312#issuecomment-232772338
+$packageParameters = $env:chocolateyPackageParameters
+$match_pattern = "(?<key>(\w+))\s*=\s*(?<value>([`"'])?([\w- _\\:\.]+)([`"'])?)"
 
-  Write-Host "Creating $env:PROGRAMDATA\consul\logs"
-  New-Item -ItemType directory -Path "$env:PROGRAMDATA\consul\logs" -ErrorAction SilentlyContinue | Out-Null
-  Write-Host "Creating $env:PROGRAMDATA\consul\config"
-  New-Item -ItemType directory -Path "$env:PROGRAMDATA\consul\config" -ErrorAction SilentlyContinue | Out-Null
-
-  # Create event log source
-  # User -Force to avoid "A key at this path already exists" exception. Overwrite not an issue since key is not further modified
-  $registryPath = 'HKLM:\SYSTEM\CurrentControlSet\services\eventlog\Application'
-  New-Item -Path $registryPath -Name consul -Force | Out-Null
-  # Set EventMessageFile value
-  Set-ItemProperty $registryPath\consul EventMessageFile "C:\Windows\Microsoft.NET\Framework64\v2.0.50727\EventLogMessages.dll" | Out-Null
-
-  # Set up task scheduler for log rotation
-  $logrotate = '%SYSTEMROOT%\System32\forfiles.exe /p \"%PROGRAMDATA%\consul\logs\" /s /m *.* /c \"cmd /c Del @path\" /d -7'
-  SchTasks.exe /Create /SC DAILY /TN ""ConsulLogrotate"" /TR ""$($logrotate)"" /ST 09:00 /F | Out-Null
-
-  # Set up task scheduler for log rotation. Only works for Powershell 4 or Server 2012R2 so this block can replace
-  # using SchTasks.exe for registering services once machines have retired the older version of PS or upgraded to 2012R2
-  #$command = '$now = Get-Date; dir "$env:PROGRAMDATA\consul\logs" | where {$_.LastWriteTime -le $now.AddDays(-7)} | del -whatif'
-  #$action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -command $($command)"
-  #$trigger = New-ScheduledTaskTrigger -Daily -At 9am
-  #Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "ConsulLogrotate" -Description "Log rotation for consul"
-
-  #Uninstall service if it already exists. Stops the service first if it's running
-  $service = Get-Service "consul" -ErrorAction SilentlyContinue
-  if ($service) {
-    Write-Host "Uninstalling existing service"
-    if ($service.Status -eq "Running") {
-      Write-Host "Stopping consul process ..."
-      net stop consul | Out-Null
+# Now parse the packageParameters using good old regular expression
+if ($packageParameters -match $match_pattern ){
+    $results = $packageParameters | Select-String $match_pattern -AllMatches
+    $results.matches | ForEach-Object {
+        Set-Variable -Name $_.Groups['key'].Value.Trim() -Value $_.Groups['value'].Value.Trim()
     }
+}
 
-    $service = Get-WmiObject -Class Win32_Service -Filter "Name='consul'"
-    $service.delete() | Out-Null
+# Consul related variables
+$consulVersion = '0.7.2'
+$sourcePath = if (Get-ProcessorBits 32) {
+  $(Join-Path $binariesPath "$($consulVersion)_windows_386.zip")
+} else {
+  $(Join-Path $binariesPath "$($consulVersion)_windows_amd64.zip")
+}
+$sourcePathUI = $(Join-Path $binariesPath "$($consulVersion)_web_ui.zip")
+
+# Create Service Directories
+Write-Host "Creating $serviceLogDirectory"
+New-Item -ItemType directory -Path "$serviceLogDirectory" -ErrorAction SilentlyContinue | Out-Null
+Write-Host "Creating $serviceConfigDirectory"
+New-Item -ItemType directory -Path "$serviceConfigDirectory" -ErrorAction SilentlyContinue | Out-Null
+Write-Host "Creating $serviceUiDirectory"
+New-Item -ItemType directory -Path "$serviceUiDirectory" -ErrorAction SilentlyContinue | Out-Null
+
+# Unzip and move Consul
+Get-ChocolateyUnzip  $sourcePath "$toolsPath"
+Get-ChocolateyUnzip  $sourcePathUI "$serviceUiDirectory"
+
+# Create event log source
+# User -Force to avoid "A key at this path already exists" exception. Overwrite not an issue since key is not further modified
+$registryPath = 'HKLM:\SYSTEM\CurrentControlSet\services\eventlog\Application'
+New-Item -Path $registryPath -Name consul -Force | Out-Null
+# Set EventMessageFile value
+Set-ItemProperty $registryPath\consul EventMessageFile "C:\Windows\Microsoft.NET\Framework64\v2.0.50727\EventLogMessages.dll" | Out-Null
+
+# Set up task scheduler for log rotation
+$logrotate = ('%SYSTEMROOT%\System32\forfiles.exe /p \"{0}\" /s /m *.* /c \"cmd /c Del @path\" /d -7' -f "$serviceLogDirectory")
+SchTasks.exe /Create /SC DAILY /TN ""ConsulLogrotate"" /TR ""$($logrotate)"" /ST 09:00 /F | Out-Null
+
+# Set up task scheduler for log rotation. Only works for Powershell 4 or Server 2012R2 so this block can replace
+# using SchTasks.exe for registering services once machines have retired the older version of PS or upgraded to 2012R2
+#$command = ('$now = Get-Date; dir "{0}" | where {{$_.LastWriteTime -le $now.AddDays(-7)}} | del -whatif' -f $serviceLogDirectory)
+#$action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -command $($command)"
+#$trigger = New-ScheduledTaskTrigger -Daily -At 9am
+#Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "ConsulLogrotate" -Description "Log rotation for consul"
+
+#Uninstall service if it already exists. Stops the service first if it's running
+$service = Get-Service $serviceName -ErrorAction SilentlyContinue
+if ($service) {
+  Write-Host "Uninstalling existing service"
+  if($service.Status -ne "Stopped" -and $service.Status -ne "Stopping") {
+    Write-Host "Stopping consul process ..."
+    $service.Stop();
   }
 
-  Write-Host "Installing the consul service"
-  # Install the service
-  & $wrapperExe install consul $(Join-Path $toolsPath "consul.exe") agent -config-dir=%PROGRAMDATA%\consul\config -data-dir=%PROGRAMDATA%\consul\data | Out-Null
-  & $wrapperExe set consul AppEnvironmentExtra GOMAXPROCS=$env:NUMBER_OF_PROCESSORS | Out-Null
-  & $wrapperExe set consul ObjectName NetworkService | Out-Null
-  & $wrapperExe set consul AppStdout "$env:PROGRAMDATA\consul\logs\consul-output.log" | Out-Null
-  & $wrapperExe set consul AppStderr "$env:PROGRAMDATA\consul\logs\consul-error.log" | Out-Null
-  & $wrapperExe set consul AppRotateBytes 10485760 | Out-Null
-  & $wrapperExe set consul AppRotateFiles 1 | Out-Null
-  & $wrapperExe set consul AppRotateOnline 1 | Out-Null
+  $service.WaitForStatus("Stopped", (New-TimeSpan -Minutes 1));
+  if($service.Status -ne "Stopped") {
+    throw "$serviceName could not be stopped within the allotted timespan.  Stop the service and try again."
+  }
 
-  # Restart service on failure natively via Windows sc. There is a memory leak if service restart is performed via NSSM
-  # The NSSM configuration will set the default behavior of NSSM to stop the service if
-  # consul fails (for example, unable to resolve cluster) and end the nssm.exe and consul.exe process.
-  # The sc configuration will set Recovery under the Consul service properties such that a new instance will be started on failure,
-  # spawning new nssm.exe and consul.exe processes. In short, nothing changed from a functionality perspective (the service will
-  # still attempt to restart on failure) but this method kills the nssm.exe process thus avoiding memory hog.
-  & $wrapperExe set consul AppExit Default Exit | Out-Null
-  cmd.exe /c "sc failure consul reset= 0 actions= restart/60000" | Out-Null
-
-  Write-ChocolateySuccess 'consul'
-} catch {
-  Write-ChocolateyFailure 'consul' $($_.Exception.Message)
-  throw
+  $service = Get-WmiObject -Class Win32_Service -Filter "Name='$serviceName'"
+  $service.delete() | Out-Null
 }
+
+Write-Host "Installing service: $serviceName"
+# Install the service
+& $wrapperExe install $serviceName $(Join-Path $toolsPath "consul.exe") "agent -ui-dir=$serviceUiDirectory -config-dir=$serviceConfigDirectory -data-dir=$serviceDataDirectory $extraArgs" | Out-Null
+& $wrapperExe set $serviceName AppEnvironmentExtra GOMAXPROCS=$env:NUMBER_OF_PROCESSORS | Out-Null
+& $wrapperExe set $serviceName ObjectName NetworkService | Out-Null
+& $wrapperExe set $serviceName AppStdout "$serviceLogDirectory\consul-output.log" | Out-Null
+& $wrapperExe set $serviceName AppStderr "$serviceLogDirectory\consul-error.log" | Out-Null
+& $wrapperExe set $serviceName AppRotateBytes 10485760 | Out-Null
+& $wrapperExe set $serviceName AppRotateFiles 1 | Out-Null
+& $wrapperExe set $serviceName AppRotateOnline 1 | Out-Null
+
+# When nssm fully supports Rotate/Post Event hooks
+# $command = ('$now = Get-Date; dir "{0}" | where {{$_.LastWriteTime -le $now.AddDays(-7)}} | del -whatif' -f $serviceLogDirectory)
+# $action = ("Powershell.exe -NoProfile -WindowStyle Hidden -command '$({{0}})'" -f $command)
+# & $wrapperExe set consul AppEvents "Rotate/Post" $action | Out-Null
+
+# Restart service on failure natively via Windows sc. There is a memory leak if service restart is performed via NSSM
+# The NSSM configuration will set the default behavior of NSSM to stop the service if
+# consul fails (for example, unable to resolve cluster) and end the nssm.exe and consul.exe process.
+# The sc configuration will set Recovery under the Consul service properties such that a new instance will be started on failure,
+# spawning new nssm.exe and consul.exe processes. In short, nothing changed from a functionality perspective (the service will
+# still attempt to restart on failure) but this method kills the nssm.exe process thus avoiding memory hog.
+& $wrapperExe set $serviceName AppExit Default Exit | Out-Null
+cmd.exe /c "sc failure $serviceName reset= 0 actions= restart/60000" | Out-Null
+
+# Let this call to Get-Service throw if the service does not exist
+$service = Get-Service $serviceName
+if($service.Status -ne "Stopped" -and $service.Status -ne "Stopping") {
+  $service.Stop()
+}
+
+$service.WaitForStatus("Stopped", (New-TimeSpan -Minutes 1));
+& $wrapperExe start $serviceName | Out-Null
+
+Write-Host "Installed service: $serviceName"


### PR DESCRIPTION
- Enables chocolatey options to be passed to install command
- Defaults to '-server -bootstrap-expect=1' to allow for single node consul cluster
- Defaults to bind to 127.0.0.1 - passing extraArgs="-server -bootstrap-expect=1 -bind=10.1.2.3"
    should allow a user to default their address to 10.1.2.3.  It is left as an exercise to the
    user to determine which IP address they should bind to.
- Moves ui into $PROGRAMDATA\consul\ui by default
- Removes deprecated Write-ChocolateySuccess and Write-ChocolateyFailure
- Removes deprecated try/catch around install