### PR TITLE
Removes default extraArgs

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -10,7 +10,7 @@ $serviceUiDirectory = "$serviceInstallationDirectory\ui"
 $serviceDataDirectory = "$serviceInstallationDirectory\data"
 
 $bindAddress = "127.0.0.1"
-$extraArgs = "-server -bootstrap-expect=1 -bind=$bindAddress"
+$extraArgs = ""
 
 # packageParameters -- https://github.com/chocolatey/choco/wiki/How-To-Parse-PackageParameters-Argument
 # https://github.com/chocolatey/choco/issues/312#issuecomment-232772338

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -9,7 +9,6 @@ $serviceConfigDirectory = "$serviceInstallationDirectory\config"
 $serviceUiDirectory = "$serviceInstallationDirectory\ui"
 $serviceDataDirectory = "$serviceInstallationDirectory\data"
 
-$bindAddress = "127.0.0.1"
 $extraArgs = ""
 
 # packageParameters -- https://github.com/chocolatey/choco/wiki/How-To-Parse-PackageParameters-Argument


### PR DESCRIPTION
Hi there,

I just got caught out by this setting which seems to have appeared in commit `a67d3f25c83dd8e9b8bdcddb47312dc31a06e8c2`. I was using this package to configure my windows nodes as consul agents, and managed to put my cluster in a bad state due to all my agents becoming servers all of a sudden! Would be good to remove as default and users can add if needed.