### PR TITLE
Patch extra args

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.7.4.{build}
+version: 0.7.4.1.{build}
 
 environment:
   TOKEN:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
 
 build_script:
   - ps: >-
-      $env:CONSUL_VERSION = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$');
+      $env:CONSUL_VERSION = ($env:APPVEYOR_BUILD_VERSION | ? {$_ -match('^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-rc\d+)?')} | select @{L="Matches";E={$matches[0]}}).matches;
       cmd /c download.bat;
       choco pack consul.nuspec
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,8 @@ build_script:
 test_script:
   - ps: cinst consul -fdvy -source "$pwd;http://chocolatey.org/api/v2/"
   - ps: cuninst -fdvy consul
+  - ps: cinst consul -fdvy -source "$pwd;http://chocolatey.org/api/v2/" -params '-bind=127.0.0.1'
+  - ps: cuninst -fdvy consul 
 
 deploy_script:
   - ps: >-

--- a/consul.nuspec
+++ b/consul.nuspec
@@ -11,8 +11,15 @@
     <projectSourceUrl>https://github.com/hashicorp/consul</projectSourceUrl>
     <packageSourceUrl>https://github.com/calvn/chocolatey-consul</packageSourceUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Consul is a tool for service discovery and configuration. Consul is distributed, highly available, and extremely scalable.
-Uses NSSM as the service wrapper. More info at: https://nssm.cc/</description>
+    <description>
+Consul is a tool for service discovery and configuration. Consul is distributed, highly available, and extremely scalable.
+Uses NSSM as the service wrapper. More info at: https://nssm.cc/
+
+#### Package Parameters
+The package parameters can be set - https://www.consul.io/docs/agent/options.html
+These parameters can be passed to the installer with the use of `-params`.
+For example: `-params '-config-file="%PROGRAMDATA%\consul\dsc-config\default.json"'`.
+    </description>
     <summary>Consul is a tool for service discovery, monitoring and configuration.</summary>
     <iconUrl>https://cdn.rawgit.com/calvn/chocolatey-consul/master/icons/consul.png</iconUrl>
     <releaseNotes>Version 0.7.4</releaseNotes>

--- a/consul.nuspec
+++ b/consul.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>consul</id>
-    <version>0.7.4</version>
+    <version>0.7.4.1</version>
     <title>Consul</title>
     <authors>Mitchell Hashimoto, Armon Dadgar, HashiCorp</authors>
     <owners>mirthy, cleung2010</owners>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -9,9 +9,6 @@ $serviceConfigDirectory = "$serviceInstallationDirectory\config"
 $serviceUiDirectory = "$serviceInstallationDirectory\ui"
 $serviceDataDirectory = "$serviceInstallationDirectory\data"
 
-$bindAddress = "127.0.0.1"
-$extraArgs = "-server -bootstrap-expect=1 -bind=$bindAddress"
-
 # packageParameters -- https://github.com/chocolatey/choco/wiki/How-To-Parse-PackageParameters-Argument
 # https://github.com/chocolatey/choco/issues/312#issuecomment-232772338
 $packageParameters = $env:chocolateyPackageParameters
@@ -84,7 +81,7 @@ if ($service) {
 
 Write-Host "Installing service: $serviceName"
 # Install the service
-& $wrapperExe install $serviceName $(Join-Path $toolsPath "consul.exe") "agent -ui-dir=$serviceUiDirectory -config-dir=$serviceConfigDirectory -data-dir=$serviceDataDirectory $extraArgs" | Out-Null
+& $wrapperExe install $serviceName $(Join-Path $toolsPath "consul.exe") "agent -ui-dir=$serviceUiDirectory -config-dir=$serviceConfigDirectory -data-dir=$serviceDataDirectory" | Out-Null
 & $wrapperExe set $serviceName AppEnvironmentExtra GOMAXPROCS=$env:NUMBER_OF_PROCESSORS | Out-Null
 & $wrapperExe set $serviceName ObjectName NetworkService | Out-Null
 & $wrapperExe set $serviceName AppStdout "$serviceLogDirectory\consul-output.log" | Out-Null

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -9,17 +9,10 @@ $serviceConfigDirectory = "$serviceInstallationDirectory\config"
 $serviceUiDirectory = "$serviceInstallationDirectory\ui"
 $serviceDataDirectory = "$serviceInstallationDirectory\data"
 
-# packageParameters -- https://github.com/chocolatey/choco/wiki/How-To-Parse-PackageParameters-Argument
-# https://github.com/chocolatey/choco/issues/312#issuecomment-232772338
 $packageParameters = $env:chocolateyPackageParameters
-$match_pattern = "(?<key>(\w+))\s*=\s*(?<value>([`"'])?([\w- _\\:\.]+)([`"'])?)"
-
-# Now parse the packageParameters using good old regular expression
-if ($packageParameters -match $match_pattern ){
-    $results = $packageParameters | Select-String $match_pattern -AllMatches
-    $results.matches | ForEach-Object {
-        Set-Variable -Name $_.Groups['key'].Value.Trim() -Value $_.Groups['value'].Value.Trim()
-    }
+if (-not ($packageParameters)) {
+  $packageParameters = ""
+  Write-Debug "No Package Parameters Passed in"
 }
 
 # Consul related variables
@@ -81,7 +74,7 @@ if ($service) {
 
 Write-Host "Installing service: $serviceName"
 # Install the service
-& $wrapperExe install $serviceName $(Join-Path $toolsPath "consul.exe") "agent -ui-dir=$serviceUiDirectory -config-dir=$serviceConfigDirectory -data-dir=$serviceDataDirectory" | Out-Null
+& $wrapperExe install $serviceName $(Join-Path $toolsPath "consul.exe") "agent -ui-dir=$serviceUiDirectory -config-dir=$serviceConfigDirectory -data-dir=$serviceDataDirectory $packageParameters" | Out-Null
 & $wrapperExe set $serviceName AppEnvironmentExtra GOMAXPROCS=$env:NUMBER_OF_PROCESSORS | Out-Null
 & $wrapperExe set $serviceName ObjectName NetworkService | Out-Null
 & $wrapperExe set $serviceName AppStdout "$serviceLogDirectory\consul-output.log" | Out-Null


### PR DESCRIPTION
@anguswilliams @arledesma @123BLiN please review these changes. 

@arledesma added $packageParameters, but it wasn't quite the way we would want to use it. Originally, the install would parse each of the params in a very specific way (matched by the regex), and would then set those to local environment variables which could be evaluated during the install. This makes sense for the example in [the docs](https://github.com/chocolatey/choco/wiki/How-To-Parse-PackageParameters-Argument), but that regex wouldn't work for consul's arguments.

I chose to go with @123BLiN's PR changes in the old repo, so props goes to him.