### PR TITLE
Updates Consul to the 1.2.1 version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.cache
 *~
-
+*.bak
+*.sh
+*.orig
 *.nupkg
 .DS_Store
 binaries

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.2.0.{build}
+version: 1.2.1.{build}
 
 environment:
   TOKEN:

--- a/consul.nuspec
+++ b/consul.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>consul</id>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <title>Consul</title>
     <authors>Mitchell Hashimoto, Armon Dadgar, HashiCorp</authors>
     <owners>mirthy, cleung2010</owners>
@@ -22,7 +22,7 @@ For example: `-params '-config-file="%PROGRAMDATA%\consul\dsc-config\default.jso
     </description>
     <summary>Consul is a tool for service discovery, monitoring and configuration.</summary>
     <iconUrl>https://cdn.rawgit.com/calvn/chocolatey-consul/master/icons/consul.png</iconUrl>
-    <releaseNotes>Version 1.2.0</releaseNotes>
+    <releaseNotes>Version 1.2.1</releaseNotes>
     <copyright>HashiCorp 2018</copyright>
     <tags>consul service consul.io</tags>
     <dependencies>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -15,7 +15,7 @@ if (-not ($packageParameters)) {
 }
 
 # Consul related variables
-$consulVersion = '1.2.0'
+$consulVersion = '1.2.1'
 $sourcePath = if (Get-ProcessorBits 32) {
   $(Join-Path $binariesPath "$($consulVersion)_windows_386.zip")
 } else {


### PR DESCRIPTION
This PR will update Consul to the 1.2.1 version, released last week. I added some changes to the .gitignore file because I wrote a bash script to make **_sed_** do the editing work, whilst it ignores the by product of the sed command's additional files, which are backups. 